### PR TITLE
adjust examples for v2, metrics, etc

### DIFF
--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -42,6 +42,15 @@ an analysis and saving results (metrics JSON, report PDF, data ZIP).
 python3 activity_analysis.py [<api_key>]
 ```
 
+### `activity_metrics.py` — Retrieve biomechanical metrics
+
+Selects a session and activity, then fetches its metrics via
+`activity_metrics` and prints them.
+
+```bash
+python3 activity_metrics.py [<api_key>]
+```
+
 ### `activity_recording.py` — Full capture workflow
 
 Walks through creating a session, calibrating cameras and subject, recording an
@@ -59,6 +68,15 @@ to it using `add_motion_data_to_activity`.
 
 ```bash
 python3 add_external_data.py [<api_key>]
+```
+
+### `update_activity.py` — Update activity metadata
+
+Selects a subject and one of their activities, then optionally updates the
+activity name and/or tags via `update_activity`.
+
+```bash
+python3 update_activity.py [<api_key>]
 ```
 
 ### `archive_session.py` — Session archive download

--- a/examples/python/activity_analysis.py
+++ b/examples/python/activity_analysis.py
@@ -12,6 +12,7 @@ Usage:
     activity_analysis.py [<api_key>]
 """
 
+import json
 import sys
 import time
 
@@ -25,6 +26,7 @@ from modelhealth import (
     AnalysisStatus,
     ActivityType,
     AnalysisDataType,
+    MetricValueBilateral,
 )
 from _prompts import pick_one, pick_multi
 from _utils import save_file, ANALYSIS_DATA_EXT, load_api_key, poll_analysis
@@ -80,6 +82,33 @@ def _poll_processing(service, activity, interval=10):
             print()  # clear the \r line
             return status
         time.sleep(interval)
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def _metrics_to_dict(metrics):
+    """Flatten ActivityMetrics into a plain dict for JSON serialisation.
+
+    Groups are discarded and every metric appears exactly once, keyed by name.
+    Scalar metrics map to a single number; bilateral metrics map to a
+    ``{"left": ..., "right": ...}`` object. The first occurrence of a name wins.
+    """
+    flat = {}
+    for group in metrics.groups:
+        for metric in group.metrics:
+            if metric.name in flat:
+                continue
+            value = metric.value
+            if isinstance(value, MetricValueBilateral):
+                flat[metric.name] = {"left": value.left, "right": value.right}
+            else:  # MetricValueScalar
+                flat[metric.name] = value.value
+    return {
+        "activity_id": metrics.activity_id,
+        "metrics": flat,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -175,15 +204,29 @@ def main(api_key):
     )
     data_types = [r[0] for r in selected]
 
-    # Download and save
-    print("\nDownloading...")
-    results = service.analysis_data_for_activity(activity, data_types)
-
     slug = (activity.name or activity.id).replace(" ", "_")
-    for r in results:
-        ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
-        path = save_file(f"{slug}_{r.type}.{ext}", r.data)
+
+    # Metrics now come from the metrics table — the AnalysisDataType.metrics
+    # download is deprecated. Fetch them and save a single flat JSON.
+    if AnalysisDataType.metrics in data_types:
+        print("\nFetching metrics...")
+        try:
+            metrics = service.activity_metrics(activity.id)
+        except ModelHealthError as exc:
+            sys.exit(f"Failed to fetch activity metrics: {exc}")
+        metrics_json = json.dumps(_metrics_to_dict(metrics), indent=2)
+        path = save_file(f"{slug}_metrics.json", metrics_json.encode("utf-8"))
         print(f"  Saved {path}")
+
+    # Report and data files still download through the analysis data endpoint.
+    file_types = [t for t in data_types if t != AnalysisDataType.metrics]
+    if file_types:
+        print("\nDownloading...")
+        results = service.analysis_data_for_activity(activity, file_types)
+        for r in results:
+            ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
+            path = save_file(f"{slug}_{r.type}.{ext}", r.data)
+            print(f"  Saved {path}")
 
     print("\nDone.")
 

--- a/examples/python/activity_metrics.py
+++ b/examples/python/activity_metrics.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-"""Model Health Python SDK — Retrieve biomechanical metrics for an activity or subject.
+"""Model Health Python SDK — Retrieve biomechanical metrics for an activity.
 
-Demonstrates ``activity_metrics`` (single-activity dashboard metrics) and
-``subject_metrics`` (all metrics across activities for a subject, with optional
-date filtering).
+Demonstrates ``activity_metrics`` (single-activity dashboard metrics).
 
 Usage:
     activity_metrics.py [<api_key>]
@@ -20,7 +18,7 @@ from modelhealth import (
     MetricValueScalar,
     MetricValueBilateral,
 )
-from _prompts import pick_one, confirm
+from _prompts import pick_one
 from _utils import load_api_key
 
 # Activities created by the mobile app for internal use — exclude from lists.
@@ -75,16 +73,29 @@ def main(api_key):
     except ModelHealthError as exc:
         sys.exit(f"Failed to fetch activity metrics: {exc}")
 
-    if not metrics.groups:
+    flat = _flatten_metrics(metrics)
+    if not flat:
         print("  No metrics available for this activity.")
     else:
-        print(f"\nActivity metrics (activity type ID: {metrics.activity_type_id}):\n")
-        for group in metrics.groups:
-            print(f"  {group.name}")
-            for metric in group.metrics:
-                print(f"    {metric.name}: {_format_value(metric.value)}")
+        print("\nActivity metrics:\n")
+        for name, value in flat.items():
+            print(f"  {name}: {_format_value(value)}")
 
     print("\nDone.")
+
+
+def _flatten_metrics(metrics):
+    """Collapse the grouped metrics into a flat name -> value mapping.
+
+    Groups are discarded and each metric appears exactly once; the first
+    occurrence of a name wins.
+    """
+    flat = {}
+    for group in metrics.groups:
+        for metric in group.metrics:
+            if metric.name not in flat:
+                flat[metric.name] = metric.value
+    return flat
 
 
 def _format_value(value):

--- a/examples/python/activity_recording.py
+++ b/examples/python/activity_recording.py
@@ -218,7 +218,15 @@ def _record_one(service, session, subject):
     else:
         print(f"Activity did not reach ready state (status: {status}).")
 
-    # Update activity metadata
+    # Update activity metadata.
+    # Re-fetch first: analysis auto-generates tags server-side, and update_activity
+    # merges add/remove_tags on top of the local activity's tags. Without a fresh
+    # fetch, the merge starts from a stale tag set and wipes the auto-generated tags.
+    try:
+        activity = service.fetch_activity(activity.id)
+    except ModelHealthError as exc:
+        print(f"Failed to refresh activity: {exc}")
+
     print("\nUpdate activity (optional):")
     current_tags = ", ".join(activity.tags) if activity.tags else "(none)"
     print(f"  Current tags: {current_tags}")

--- a/examples/python/opencap_import.py
+++ b/examples/python/opencap_import.py
@@ -19,7 +19,6 @@ from modelhealth import (
     ModelHealthService,
     SubjectParameters,
     SessionConfig,
-    SessionFramerate,
     SessionOpenSimModel,
     SessionScalingSetup,
     SessionCoreEngine,
@@ -53,13 +52,6 @@ _CORE_ENGINE_MAP = {
     "v0.3": SessionCoreEngine.v0_3,
     "v1.0": SessionCoreEngine.v1_0,
 }
-
-_FRAMERATE_MAP = {
-    "60": SessionFramerate.fps_60,
-    "120": SessionFramerate.fps_120,
-    "240": SessionFramerate.fps_240,
-}
-
 
 def _filter_frequency_from_meta(value):
     if value is None or value == "default":
@@ -110,7 +102,8 @@ def copy_session(
                 - "scalingsetup": "upright_standing_pose" | "any_pose"
                 - "coreengine": "v0.2" | "v0.3" | "v1.0"
                 - "filterfrequency": "default" | <integer>
-                - "framerate": "60" | "120" | "240"
+            The framerate is always taken from the source session (it is intrinsic to the
+            recorded videos) and cannot be overridden.
         trials_to_import: Optional list of trial names to import. Setup trials
             (calibration, neutral) are always included. Set to None to import all trials.
         trial_meta_overrides: Optional dict keyed by trial name. Each value is a dict of
@@ -130,7 +123,6 @@ def copy_session(
 
     if meta_overrides:
         session_config = SessionConfig(
-            framerate=_FRAMERATE_MAP.get(str(meta_overrides.get("framerate") or ""), SessionFramerate.fps_120),
             opensim_model=_OPENSIM_MODEL_MAP.get(meta_overrides.get("openSimModel"), SessionOpenSimModel.lai_uhlrich_2022_shoulder),
             scaling_setup=_SCALING_SETUP_MAP.get(meta_overrides.get("scalingsetup"), SessionScalingSetup.upright_standing_pose),
             core_engine=_CORE_ENGINE_MAP.get(meta_overrides.get("coreengine"), SessionCoreEngine.v1_0),
@@ -204,7 +196,17 @@ def copy_session(
     # Build the full source session meta with settings overrides applied so the
     # backend has all the context it needs (e.g. sessionWithCalibration).
     session_meta = dict(meta)
-    session_meta.setdefault("settings", {}).update(meta_overrides or {})
+    settings = dict(session_meta.get("settings") or {})
+    # Translate OpenCap's augmentermodel to Model Health's coreengine up front, so an explicit
+    # coreengine override below wins (otherwise the backend re-applies augmentermodel over it).
+    if "augmentermodel" in settings:
+        settings["coreengine"] = settings.pop("augmentermodel")
+    # posemodel is an OpenCap-only setting, unused in Model Health.
+    settings.pop("posemodel", None)
+    # Framerate is intrinsic to the recorded videos, so always keep the source session's
+    # value — drop any framerate from the overrides so it can never be changed here.
+    settings.update({k: v for k, v in (meta_overrides or {}).items() if k != "framerate"})
+    session_meta["settings"] = settings
 
     # Annotate trials with per-trial overrides (e.g. activity_type).
     # Setup trials are never annotated — only dynamic trials support activity_type.
@@ -240,8 +242,15 @@ def copy_session(
             trial = _current_trial[0] or "activity"
             print(f"  [{trial}] Processing...")
 
+    # The v2 API rejects any direct trial `meta` update, so drop the source meta
+    # before import — the backend derives what it needs from settings and activity_type.
+    import_trials = [
+        {k: v for k, v in t.items() if k != "meta"}
+        for t in [calibration_trial, neutral_trial, *annotated_trials]
+    ]
+
     session = mh_service.import_session(
-        json.dumps([calibration_trial, neutral_trial, *annotated_trials]),
+        json.dumps(import_trials),
         subject,
         session_config=session_config,
         session_meta_json=json.dumps(session_meta),
@@ -323,24 +332,19 @@ if __name__ == "__main__":
         "scalingsetup": "upright_standing_pose",    # "upright_standing_pose" | "any_pose"
         "coreengine": "v1.0",                       # "v0.2" | "v0.3" | "v1.0"
         "filterfrequency": "default",               # "default" | <integer Hz>
-        # "framerate": "60",                        # "60" | "120" | "240" — override source framerate
     }
 
     # Trials to import. Setup trials (calibration, neutral) are always included.
     # Set to None to import all trials.
     trials_to_import = None
-    # trials_to_import = ["trial1", "trial2"]  # example: import specific trials
+    # trials_to_import = ["test", "test1"]  # example: import specific trials
 
     # Optional per-trial overrides keyed by trial name.
     # Setting "activity_type" will auto-launch analysis after processing.
-    # trial_meta_overrides = {}
-    trial_meta_overrides = {
-        "test": {"activity_type": ActivityType.range_of_motion},
-        # "trial2": {"activity_type": ActivityType.counter_movement_jump},
-    }
+    trial_meta_overrides = {}
     # trial_meta_overrides = {
-    #     "trial1": {"activity_type": ActivityType.range_of_motion},
-    #     "trial2": {"activity_type": ActivityType.counter_movement_jump},
+    #     "test": {"activity_type": ActivityType.range_of_motion},
+    #     "test1": {"activity_type": ActivityType.counter_movement_jump},
     # }
 
     mh_service = ModelHealthService(load_api_key(args["--api-key"]))

--- a/examples/python/session_data.py
+++ b/examples/python/session_data.py
@@ -9,6 +9,7 @@ Usage:
     session_data.py [<api_key>]
 """
 
+import json
 import sys
 
 from docopt import docopt
@@ -20,6 +21,7 @@ from modelhealth import (
     MotionDataType,
     AnalysisDataType,
     VideoVersion,
+    MetricValueBilateral,
 )
 from _prompts import pick_one, pick_multi
 from _utils import save_file, MOTION_DATA_EXT, ANALYSIS_DATA_EXT, load_api_key
@@ -48,6 +50,33 @@ ANALYSIS_DATA_TYPES = [
     (AnalysisDataType.report,  "Report   (PDF) "),
     (AnalysisDataType.data,    "Data     (ZIP) "),
 ]
+
+
+# ---------------------------------------------------------------------------
+# Metrics
+# ---------------------------------------------------------------------------
+
+def _metrics_to_dict(metrics):
+    """Flatten ActivityMetrics into a plain dict for JSON serialisation.
+
+    Groups are discarded and every metric appears exactly once, keyed by name.
+    Scalar metrics map to a single number; bilateral metrics map to a
+    ``{"left": ..., "right": ...}`` object. The first occurrence of a name wins.
+    """
+    flat = {}
+    for group in metrics.groups:
+        for metric in group.metrics:
+            if metric.name in flat:
+                continue
+            value = metric.value
+            if isinstance(value, MetricValueBilateral):
+                flat[metric.name] = {"left": value.left, "right": value.right}
+            else:  # MetricValueScalar
+                flat[metric.name] = value.value
+    return {
+        "activity_id": metrics.activity_id,
+        "metrics": flat,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -151,15 +180,30 @@ def main(api_key):
     )
     analysis_types = [t[0] for t in selected_analysis]
 
-    print("\nDownloading analysis data...")
-    results = service.analysis_data_for_activity(activity, analysis_types)
-    if not results:
-        print("  No analysis data available.")
-    else:
-        for r in results:
-            ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
-            path = save_file(f"{slug}_{r.type}.{ext}", r.data)
+    # Metrics now come from the metrics table — the AnalysisDataType.metrics
+    # download is deprecated. Fetch them and save a single flat JSON.
+    if AnalysisDataType.metrics in analysis_types:
+        print("\nFetching metrics...")
+        try:
+            metrics = service.activity_metrics(activity.id)
+            metrics_json = json.dumps(_metrics_to_dict(metrics), indent=2)
+            path = save_file(f"{slug}_metrics.json", metrics_json.encode("utf-8"))
             print(f"  Saved: {path}")
+        except ModelHealthError as exc:
+            print(f"  Failed to fetch metrics: {exc}")
+
+    # Report and data files still download through the analysis data endpoint.
+    file_types = [t for t in analysis_types if t != AnalysisDataType.metrics]
+    if file_types:
+        print("\nDownloading analysis data...")
+        results = service.analysis_data_for_activity(activity, file_types)
+        if not results:
+            print("  No analysis data available.")
+        else:
+            for r in results:
+                ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
+                path = save_file(f"{slug}_{r.type}.{ext}", r.data)
+                print(f"  Saved: {path}")
 
     # OpenSim model from neutral activity
     neutral_activities = [a for a in all_activities if a.name == "neutral"]


### PR DESCRIPTION
# Examples: v2 API fixes, metrics-table migration, and OpenCap import hardening

Updates the Python examples for the v2 API and the new metrics table, and fixes
several issues found while running them end-to-end against dev.

## Metrics: migrate to the metrics table

The `AnalysisDataType.metrics` download is deprecated; metrics now come from the
metrics table via `activity_metrics`.

- **`activity_analysis.py`, `session_data.py`** — when `metrics` is selected, fetch via
  `activity_metrics` and save a single flat JSON (`<slug>_metrics.json`) instead of the
  deprecated analysis-data download. Report and data files still download through
  `analysis_data_for_activity`. Adds a shared `_metrics_to_dict` helper (scalar →
  number, bilateral → `{"left", "right"}`).
- **`activity_metrics.py`** — scoped down to single-activity metrics only (dropped the
  `subject_metrics` demo). Flattens the grouped metrics to a `name → value` mapping and
  drops the `activity_type_id` display.

## OpenCap import (`opencap_import.py`)

Fixes for importing OpenCap sessions into a v2 backend:

- **v2 rejects direct trial `meta` updates** (`"Direct meta updates are not allowed."`),
  which caused a bare `HTTP 400` on the first trial carrying meta (e.g. calibration).
  The source trial `meta` is now stripped before `import_session`.
- **`coreengine` override was silently ignored.** The source `augmentermodel` was being
  re-applied over an explicit override (e.g. `v1.0` reverted to `v0.3`). The script now
  translates `augmentermodel → coreengine` up front so the override wins.
- **Drop `posemodel`** from the session meta — it is an OpenCap-only setting, unused in
  Model Health.
- **Remove the session-level framerate override.** Framerate is intrinsic to the recorded
  videos, so it is always taken from the source session and can no longer be overridden
  (removed the `framerate` key, `_FRAMERATE_MAP`, and `SessionFramerate` import).
- Example config tidy-up: `trial_meta_overrides` defaults to empty with clearer sample
  trial names.

## Recording (`activity_recording.py`)

- Re-fetch the activity before `update_activity`. Analysis auto-generates tags
  server-side, and `update_activity` merges add/remove tags on top of the local
  activity's tags — without a fresh fetch the merge started from a stale set and wiped
  the auto-generated tags.

## Docs (`README.md`)

- Added entries for `activity_metrics.py` and `update_activity.py`.

## Testing

- OpenCap import: reproduced the full import HTTP sequence against
  `dev.modelhealth.io/api/v2`. Confirmed the trial-meta patch is what returned 400, that
  stripping it lets the import proceed, and — via patch + read-back — that a
  `coreengine: "v1.0"` override is stored as `v1.0`, `posemodel` is absent, and the
  source `framerate` is preserved.

## Related

The underlying SDK fixes (skip raw meta patch on v2, `augmentermodel`/`coreengine`
precedence, drop `posemodel`) are in a separate `model-health-internal` PR. The example
changes here also work with the currently-shipped SDK ahead of that rebuild.
