### PR TITLE
Replicate example v2/metrics changes in Swift and TypeScript

### DIFF
--- a/examples/python/_prompts.py
+++ b/examples/python/_prompts.py
@@ -1,12 +1,32 @@
 """Interactive prompt helpers shared across the Model Health demo scripts."""
 
 
-def pick_one(items, prompt, label_fn):
-    """Display a numbered list and return the item the user selects."""
+def pick_one(items, prompt, label_fn, default=None):
+    """Display a numbered list and return the item the user selects.
+
+    Pass ``default`` as an item already in ``items`` to pre-select it;
+    the user can then press Enter to accept it.
+    """
+    default_idx = None
+    if default is not None:
+        try:
+            default_idx = items.index(default)
+        except ValueError:
+            pass
+
     for i, item in enumerate(items, 1):
-        print(f"  {i}. {label_fn(item)}")
+        suffix = "  (default)" if i - 1 == default_idx else ""
+        print(f"  {i}. {label_fn(item)}{suffix}")
+
+    if default_idx is not None:
+        range_hint = f"1-{len(items)}, Enter for {default_idx + 1}"
+    else:
+        range_hint = f"1-{len(items)}"
+
     while True:
-        raw = input(f"{prompt} [1-{len(items)}]: ").strip()
+        raw = input(f"{prompt} [{range_hint}]: ").strip()
+        if raw == "" and default_idx is not None:
+            return items[default_idx]
         try:
             idx = int(raw) - 1
             if 0 <= idx < len(items):

--- a/examples/python/_utils.py
+++ b/examples/python/_utils.py
@@ -66,7 +66,6 @@ MOTION_DATA_EXT = {
 
 # File extensions for analysis data types (keyed by AnalysisData.type string).
 ANALYSIS_DATA_EXT = {
-    "metrics": "json",
     "report":  "pdf",
     "data":    "zip",
 }

--- a/examples/python/activity_analysis.py
+++ b/examples/python/activity_analysis.py
@@ -6,7 +6,7 @@ Walks through the post-capture workflow:
   2. Select an activity from that session
   3. Wait for processing to complete (if needed)
   4. Choose an analysis type and run it
-  5. Choose which result files to save (metrics JSON, report PDF, data ZIP)
+  5. Choose which result files to save (report PDF, data ZIP)
 
 Usage:
     activity_analysis.py [<api_key>]
@@ -52,7 +52,6 @@ ANALYSIS_TYPES = [
 ]
 
 RESULT_TYPES = [
-    (AnalysisDataType.metrics, "Metrics  (JSON)"),
     (AnalysisDataType.report,  "Report   (PDF) "),
     (AnalysisDataType.data,    "Data     (ZIP) "),
 ]

--- a/examples/python/activity_analysis.py
+++ b/examples/python/activity_analysis.py
@@ -12,7 +12,6 @@ Usage:
     activity_analysis.py [<api_key>]
 """
 
-import json
 import sys
 import time
 
@@ -26,7 +25,6 @@ from modelhealth import (
     AnalysisStatus,
     ActivityType,
     AnalysisDataType,
-    MetricValueBilateral,
 )
 from _prompts import pick_one, pick_multi
 from _utils import save_file, ANALYSIS_DATA_EXT, load_api_key, poll_analysis
@@ -81,33 +79,6 @@ def _poll_processing(service, activity, interval=10):
             print()  # clear the \r line
             return status
         time.sleep(interval)
-
-
-# ---------------------------------------------------------------------------
-# Metrics
-# ---------------------------------------------------------------------------
-
-def _metrics_to_dict(metrics):
-    """Flatten ActivityMetrics into a plain dict for JSON serialisation.
-
-    Groups are discarded and every metric appears exactly once, keyed by name.
-    Scalar metrics map to a single number; bilateral metrics map to a
-    ``{"left": ..., "right": ...}`` object. The first occurrence of a name wins.
-    """
-    flat = {}
-    for group in metrics.groups:
-        for metric in group.metrics:
-            if metric.name in flat:
-                continue
-            value = metric.value
-            if isinstance(value, MetricValueBilateral):
-                flat[metric.name] = {"left": value.left, "right": value.right}
-            else:  # MetricValueScalar
-                flat[metric.name] = value.value
-    return {
-        "activity_id": metrics.activity_id,
-        "metrics": flat,
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -210,27 +181,12 @@ def main(api_key):
 
     slug = (activity.name or activity.id).replace(" ", "_")
 
-    # Metrics now come from the metrics table — the AnalysisDataType.metrics
-    # download is deprecated. Fetch them and save a single flat JSON.
-    if AnalysisDataType.metrics in data_types:
-        print("\nFetching metrics...")
-        try:
-            metrics = service.activity_metrics(activity.id)
-        except ModelHealthError as exc:
-            sys.exit(f"Failed to fetch activity metrics: {exc}")
-        metrics_json = json.dumps(_metrics_to_dict(metrics), indent=2)
-        path = save_file(f"{slug}_metrics.json", metrics_json.encode("utf-8"))
+    print("\nDownloading...")
+    results = service.analysis_data_for_activity(activity, data_types)
+    for r in results:
+        ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
+        path = save_file(f"{slug}_{r.type}.{ext}", r.data)
         print(f"  Saved {path}")
-
-    # Report and data files still download through the analysis data endpoint.
-    file_types = [t for t in data_types if t != AnalysisDataType.metrics]
-    if file_types:
-        print("\nDownloading...")
-        results = service.analysis_data_for_activity(activity, file_types)
-        for r in results:
-            ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
-            path = save_file(f"{slug}_{r.type}.{ext}", r.data)
-            print(f"  Saved {path}")
 
     print("\nDone.")
 

--- a/examples/python/activity_analysis.py
+++ b/examples/python/activity_analysis.py
@@ -121,7 +121,7 @@ def main(api_key):
     activity = pick_one(
         activities,
         "Select activity",
-        lambda a: f"{a.name or a.id}  [{a.status}]",
+        lambda a: f"{a.name or a.id}  [{a.status}]" + (f"  {a.activity_type}" if a.activity_type else ""),
     )
 
     # Processing status
@@ -140,12 +140,17 @@ def main(api_key):
         )
     print("Activity is ready.")
 
-    # Analysis type
+    # Analysis type — default to the activity's recorded type if available.
+    default_analysis = next(
+        (t for t in ANALYSIS_TYPES if t[0] == activity.activity_type),
+        None,
+    )
     print("\nAnalysis type:\n")
     analysis_value, analysis_label = pick_one(
         ANALYSIS_TYPES,
         "Select analysis type",
         lambda t: t[1],
+        default=default_analysis,
     )
 
     # Run analysis

--- a/examples/python/activity_metrics.py
+++ b/examples/python/activity_metrics.py
@@ -18,8 +18,8 @@ from modelhealth import (
     MetricValueScalar,
     MetricValueBilateral,
 )
-from _prompts import pick_one
-from _utils import load_api_key
+from _prompts import pick_one, confirm
+from _utils import load_api_key, save_file
 
 # Activities created by the mobile app for internal use — exclude from lists.
 _INTERNAL_ACTIVITY_NAMES = {"calibration", "neutral"}
@@ -80,6 +80,11 @@ def main(api_key):
         print("\nActivity metrics:\n")
         for name, value in flat.items():
             print(f"  {name}: {_format_value(value)}")
+
+        if confirm("\nSave metrics as JSON?", default=False):
+            slug = activity_label.replace(" ", "_")
+            path = save_file(f"{slug}_metrics.json", metrics.to_json().encode("utf-8"))
+            print(f"  Saved {path}")
 
     print("\nDone.")
 

--- a/examples/python/session_data.py
+++ b/examples/python/session_data.py
@@ -9,7 +9,6 @@ Usage:
     session_data.py [<api_key>]
 """
 
-import json
 import sys
 
 from docopt import docopt
@@ -21,7 +20,6 @@ from modelhealth import (
     MotionDataType,
     AnalysisDataType,
     VideoVersion,
-    MetricValueBilateral,
 )
 from _prompts import pick_one, pick_multi
 from _utils import save_file, MOTION_DATA_EXT, ANALYSIS_DATA_EXT, load_api_key
@@ -49,33 +47,6 @@ ANALYSIS_DATA_TYPES = [
     (AnalysisDataType.report,  "Report   (PDF) "),
     (AnalysisDataType.data,    "Data     (ZIP) "),
 ]
-
-
-# ---------------------------------------------------------------------------
-# Metrics
-# ---------------------------------------------------------------------------
-
-def _metrics_to_dict(metrics):
-    """Flatten ActivityMetrics into a plain dict for JSON serialisation.
-
-    Groups are discarded and every metric appears exactly once, keyed by name.
-    Scalar metrics map to a single number; bilateral metrics map to a
-    ``{"left": ..., "right": ...}`` object. The first occurrence of a name wins.
-    """
-    flat = {}
-    for group in metrics.groups:
-        for metric in group.metrics:
-            if metric.name in flat:
-                continue
-            value = metric.value
-            if isinstance(value, MetricValueBilateral):
-                flat[metric.name] = {"left": value.left, "right": value.right}
-            else:  # MetricValueScalar
-                flat[metric.name] = value.value
-    return {
-        "activity_id": metrics.activity_id,
-        "metrics": flat,
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -179,30 +150,15 @@ def main(api_key):
     )
     analysis_types = [t[0] for t in selected_analysis]
 
-    # Metrics now come from the metrics table — the AnalysisDataType.metrics
-    # download is deprecated. Fetch them and save a single flat JSON.
-    if AnalysisDataType.metrics in analysis_types:
-        print("\nFetching metrics...")
-        try:
-            metrics = service.activity_metrics(activity.id)
-            metrics_json = json.dumps(_metrics_to_dict(metrics), indent=2)
-            path = save_file(f"{slug}_metrics.json", metrics_json.encode("utf-8"))
+    print("\nDownloading analysis data...")
+    results = service.analysis_data_for_activity(activity, analysis_types)
+    if not results:
+        print("  No analysis data available.")
+    else:
+        for r in results:
+            ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
+            path = save_file(f"{slug}_{r.type}.{ext}", r.data)
             print(f"  Saved: {path}")
-        except ModelHealthError as exc:
-            print(f"  Failed to fetch metrics: {exc}")
-
-    # Report and data files still download through the analysis data endpoint.
-    file_types = [t for t in analysis_types if t != AnalysisDataType.metrics]
-    if file_types:
-        print("\nDownloading analysis data...")
-        results = service.analysis_data_for_activity(activity, file_types)
-        if not results:
-            print("  No analysis data available.")
-        else:
-            for r in results:
-                ext = ANALYSIS_DATA_EXT.get(r.type, "bin")
-                path = save_file(f"{slug}_{r.type}.{ext}", r.data)
-                print(f"  Saved: {path}")
 
     # OpenSim model from neutral activity
     neutral_activities = [a for a in all_activities if a.name == "neutral"]

--- a/examples/python/session_data.py
+++ b/examples/python/session_data.py
@@ -86,7 +86,7 @@ def main(api_key):
     activity = pick_one(
         activities,
         "Select activity",
-        lambda a: f"{a.name or a.id}  [{a.status}]",
+        lambda a: f"{a.name or a.id}  [{a.status}]" + (f"  {a.activity_type}" if a.activity_type else ""),
     )
 
     # Check status

--- a/examples/python/session_data.py
+++ b/examples/python/session_data.py
@@ -44,7 +44,6 @@ MOTION_DATA_TYPES = [
 ]
 
 ANALYSIS_DATA_TYPES = [
-    (AnalysisDataType.metrics, "Metrics  (JSON)"),
     (AnalysisDataType.report,  "Report   (PDF) "),
     (AnalysisDataType.data,    "Data     (ZIP) "),
 ]

--- a/examples/python/update_activity.py
+++ b/examples/python/update_activity.py
@@ -85,12 +85,13 @@ def main(api_key):
     activity = pick_one(
         activities,
         "Select activity",
-        lambda a: f"{a.name or a.id}  [{a.status}]",
+        lambda a: f"{a.name or a.id}  [{a.status}]" + (f"  {a.activity_type}" if a.activity_type else ""),
     )
     print(f"  Selected: {activity.name or activity.id}")
 
     # Update
     print("\nUpdate activity (press Enter to keep current value):")
+    print(f"  Current activity type: {activity.activity_type or '(none)'}")
     current_tags = ", ".join(activity.tags) if activity.tags else "(none)"
     print(f"  Current tags: {current_tags}")
 

--- a/examples/swift/Sources/ActivityAnalysis/ActivityAnalysis.swift
+++ b/examples/swift/Sources/ActivityAnalysis/ActivityAnalysis.swift
@@ -26,7 +26,6 @@ private let analysisTypes: [(ActivityType, String)] = [
 ]
 
 private let resultTypes: [(AnalysisDataType, String)] = [
-    (.metrics, "Metrics  (JSON)"),
     (.report,  "Report   (PDF) "),
     (.data,    "Data     (ZIP) "),
 ]
@@ -95,7 +94,7 @@ struct ActivityAnalysis {
         let activity = pickOne(
             from: activities,
             prompt: "Select activity",
-            label: { a in "\(a.name ?? a.id)  [\(a.status)]" }
+            label: { a in "\(a.name ?? a.id)  [\(a.status)]" + (a.activityType.map { "  \($0)" } ?? "") }
         )
 
         // Wait for ready
@@ -123,12 +122,14 @@ struct ActivityAnalysis {
         }
         print("Activity is ready.")
 
-        // Analysis type
+        // Analysis type — default to the activity's recorded type if available.
+        let defaultAnalysisIndex = analysisTypes.firstIndex { $0.0 == activity.activityType }
         print("\nAnalysis type:\n")
         let (analysisType, analysisLabel) = pickOne(
             from: analysisTypes,
             prompt: "Select analysis type",
-            label: { $0.1 }
+            label: { $0.1 },
+            defaultIndex: defaultAnalysisIndex
         )
 
         // Run
@@ -171,59 +172,15 @@ struct ActivityAnalysis {
 
         let slug = (freshActivity.name ?? freshActivity.id).replacingOccurrences(of: " ", with: "_")
 
-        // Metrics now come from the metrics table — the AnalysisDataType.metrics
-        // download is deprecated. Fetch them and save a single flat JSON.
-        if dataTypes.contains(.metrics) {
-            print("\nFetching metrics...")
-            let metricsResult: ActivityMetrics?
-            do {
-                metricsResult = try await service.activityMetrics(for: freshActivity.id)
-            } catch {
-                fputs("Failed to fetch activity metrics: \(error)\n", stderr)
-                exit(1)
-            }
-            if let metrics = metricsResult, let data = metricsJSON(metrics) {
-                let path = saveFile(named: "\(slug)_metrics.json", data: data)
-                print("  Saved \(path)")
-            } else {
-                print("  No metrics available for this activity.")
-            }
-        }
-
-        // Report and data files still download through the analysis data endpoint.
-        let fileTypes = dataTypes.subtracting([.metrics])
-        if !fileTypes.isEmpty {
-            print("\nDownloading...")
-            let results = await service.analysisData(ofType: fileTypes, for: freshActivity)
-            for r in results {
-                let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
-                print("  Saved \(path)")
-            }
+        print("\nDownloading...")
+        let results = await service.analysisData(ofType: dataTypes, for: freshActivity)
+        for r in results {
+            let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
+            print("  Saved \(path)")
         }
 
         print("\nDone.")
     }
-}
-
-/// Flatten activity metrics into pretty-printed JSON.
-///
-/// Groups are discarded and every metric appears exactly once, keyed by name.
-/// Scalar metrics map to a number; bilateral metrics map to a
-/// { "left", "right" } object. The first occurrence of a name wins.
-private func metricsJSON(_ metrics: ActivityMetrics) -> Data? {
-    var flat: [String: Any] = [:]
-    for group in metrics.groups {
-        for metric in group.metrics where flat[metric.name] == nil {
-            switch metric.value {
-            case .scalar(let v):
-                flat[metric.name] = v ?? NSNull()
-            case .bilateral(let left, let right):
-                flat[metric.name] = ["left": left ?? NSNull(), "right": right ?? NSNull()]
-            }
-        }
-    }
-    let root: [String: Any] = ["activityId": metrics.activityId, "metrics": flat]
-    return try? JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
 }
 
 private func pollActivity(service: ModelHealthService, activity: Activity) async -> ActivityStatus {

--- a/examples/swift/Sources/ActivityAnalysis/ActivityAnalysis.swift
+++ b/examples/swift/Sources/ActivityAnalysis/ActivityAnalysis.swift
@@ -169,16 +169,61 @@ struct ActivityAnalysis {
         let selected = pickMulti(from: resultTypes, prompt: "Select result types", label: { $0.1 })
         let dataTypes = Set(selected.map { $0.0 })
 
-        print("\nDownloading...")
-        let results = await service.analysisData(ofType: dataTypes, for: freshActivity)
         let slug = (freshActivity.name ?? freshActivity.id).replacingOccurrences(of: " ", with: "_")
-        for r in results {
-            let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
-            print("  Saved \(path)")
+
+        // Metrics now come from the metrics table — the AnalysisDataType.metrics
+        // download is deprecated. Fetch them and save a single flat JSON.
+        if dataTypes.contains(.metrics) {
+            print("\nFetching metrics...")
+            let metricsResult: ActivityMetrics?
+            do {
+                metricsResult = try await service.activityMetrics(for: freshActivity.id)
+            } catch {
+                fputs("Failed to fetch activity metrics: \(error)\n", stderr)
+                exit(1)
+            }
+            if let metrics = metricsResult, let data = metricsJSON(metrics) {
+                let path = saveFile(named: "\(slug)_metrics.json", data: data)
+                print("  Saved \(path)")
+            } else {
+                print("  No metrics available for this activity.")
+            }
+        }
+
+        // Report and data files still download through the analysis data endpoint.
+        let fileTypes = dataTypes.subtracting([.metrics])
+        if !fileTypes.isEmpty {
+            print("\nDownloading...")
+            let results = await service.analysisData(ofType: fileTypes, for: freshActivity)
+            for r in results {
+                let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
+                print("  Saved \(path)")
+            }
         }
 
         print("\nDone.")
     }
+}
+
+/// Flatten activity metrics into pretty-printed JSON.
+///
+/// Groups are discarded and every metric appears exactly once, keyed by name.
+/// Scalar metrics map to a number; bilateral metrics map to a
+/// { "left", "right" } object. The first occurrence of a name wins.
+private func metricsJSON(_ metrics: ActivityMetrics) -> Data? {
+    var flat: [String: Any] = [:]
+    for group in metrics.groups {
+        for metric in group.metrics where flat[metric.name] == nil {
+            switch metric.value {
+            case .scalar(let v):
+                flat[metric.name] = v ?? NSNull()
+            case .bilateral(let left, let right):
+                flat[metric.name] = ["left": left ?? NSNull(), "right": right ?? NSNull()]
+            }
+        }
+    }
+    let root: [String: Any] = ["activityId": metrics.activityId, "metrics": flat]
+    return try? JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
 }
 
 private func pollActivity(service: ModelHealthService, activity: Activity) async -> ActivityStatus {

--- a/examples/swift/Sources/ActivityMetrics/ActivityMetrics.swift
+++ b/examples/swift/Sources/ActivityMetrics/ActivityMetrics.swift
@@ -1,7 +1,6 @@
 /// Model Health Swift examples — retrieve biomechanical metrics.
 ///
-/// Demonstrates activityMetrics (single-activity dashboard metrics) and
-/// subjectMetrics (all metrics across activities for a subject).
+/// Demonstrates activityMetrics (single-activity dashboard metrics).
 ///
 /// Usage:
 ///   swift run ActivityMetrics [<api_key>]
@@ -87,68 +86,36 @@ struct ActivityMetricsScript {
         }
 
         if let metrics = metricsResult {
-            if metrics.groups.isEmpty {
+            let flat = flattenMetrics(metrics)
+            if flat.isEmpty {
                 print("  No metrics available for this activity.")
             } else {
-                print("\nActivity metrics (activity type ID: \(metrics.activityTypeId)):\n")
-                for group in metrics.groups {
-                    print("  \(group.name)")
-                    for metric in group.metrics {
-                        print("    \(metric.name): \(formattedValue(metric.value))")
-                    }
+                print("\nActivity metrics:\n")
+                for (name, value) in flat {
+                    print("  \(name): \(formattedValue(value))")
                 }
             }
         } else {
             print("  No metrics yet — this activity has not been analysed.")
         }
 
-        // Subject metrics (optional)
-        print("\n" + String(repeating: "-", count: 40))
-        print("\nFetching subjects...")
-        let subjects: [Subject]
-        do {
-            subjects = try await service.subjectList()
-        } catch {
-            fputs("Failed to fetch subjects: \(error)\n", stderr)
-            print("\nDone.")
-            return
-        }
-
-        guard !subjects.isEmpty else {
-            print("No subjects found — skipping subject metrics.")
-            print("\nDone.")
-            return
-        }
-
-        print("\n\(subjects.count) subject(s):\n")
-        let subject = pickOne(
-            from: subjects,
-            prompt: "Select subject (or Ctrl-C to skip)",
-            label: { s in "[ID: \(s.id)]  \(s.name)" }
-        )
-
-        print("\nFetching metrics for subject '\(subject.name)' (ID: \(subject.id))...")
-        let subjectMetrics: [ActivityMetrics]
-        do {
-            subjectMetrics = try await service.subjectMetrics(forSubject: subject.id)
-        } catch {
-            fputs("Failed to fetch subject metrics: \(error)\n", stderr)
-            print("\nDone.")
-            return
-        }
-
-        if subjectMetrics.isEmpty {
-            print("  No metrics found for this subject.")
-        } else {
-            print("\n  \(subjectMetrics.count) activity result(s):\n")
-            for am in subjectMetrics {
-                let total = am.groups.reduce(0) { $0 + $1.metrics.count }
-                print("  Activity \(am.activityId)  (type ID: \(am.activityTypeId))  — \(total) metric(s)")
-            }
-        }
-
         print("\nDone.")
     }
+}
+
+/// Collapse the grouped metrics into a flat (name, value) list.
+///
+/// Groups are discarded and each metric appears exactly once, preserving order;
+/// the first occurrence of a name wins.
+private func flattenMetrics(_ metrics: ActivityMetrics) -> [(String, MetricValue)] {
+    var seen = Set<String>()
+    var flat: [(String, MetricValue)] = []
+    for group in metrics.groups {
+        for metric in group.metrics where seen.insert(metric.name).inserted {
+            flat.append((metric.name, metric.value))
+        }
+    }
+    return flat
 }
 
 private func formattedValue(_ value: MetricValue) -> String {

--- a/examples/swift/Sources/ActivityMetrics/ActivityMetrics.swift
+++ b/examples/swift/Sources/ActivityMetrics/ActivityMetrics.swift
@@ -94,6 +94,16 @@ struct ActivityMetricsScript {
                 for (name, value) in flat {
                     print("  \(name): \(formattedValue(value))")
                 }
+
+                if confirm("\nSave metrics as JSON?", default: false) {
+                    let slug = activityLabel.replacingOccurrences(of: " ", with: "_")
+                    do {
+                        let path = saveFile(named: "\(slug)_metrics.json", data: Data(try metrics.jsonString().utf8))
+                        print("  Saved \(path)")
+                    } catch {
+                        print("  Failed to serialise metrics: \(error)")
+                    }
+                }
             }
         } else {
             print("  No metrics yet — this activity has not been analysed.")

--- a/examples/swift/Sources/ActivityRecording/ActivityRecording.swift
+++ b/examples/swift/Sources/ActivityRecording/ActivityRecording.swift
@@ -330,7 +330,16 @@ private func recordOne(service: ModelHealthService, session: Session, subject: S
         print("Activity did not reach ready state (status: \(finalStatus)).")
     }
 
-    // Update activity metadata (optional)
+    // Update activity metadata (optional).
+    // Re-fetch first: analysis auto-generates tags server-side, and update(activity:)
+    // merges add/remove tags on top of the local activity's tags. Without a fresh
+    // fetch, the merge starts from a stale tag set and wipes the auto-generated tags.
+    do {
+        currentActivity = try await service.fetch(activity: currentActivity.id)
+    } catch {
+        fputs("Failed to refresh activity: \(error)\n", stderr)
+    }
+
     print("\nUpdate activity (optional):")
     let currentTags = currentActivity.tags.isEmpty ? "(none)" : currentActivity.tags.joined(separator: ", ")
     print("  Current tags: \(currentTags)")

--- a/examples/swift/Sources/SessionData/SessionData.swift
+++ b/examples/swift/Sources/SessionData/SessionData.swift
@@ -20,7 +20,6 @@ private let motionDataTypes: [(MotionDataType, String)] = [
 ]
 
 private let analysisDataTypes: [(AnalysisDataType, String)] = [
-    (.metrics, "Metrics  (JSON)"),
     (.report,  "Report   (PDF) "),
     (.data,    "Data     (ZIP) "),
 ]
@@ -87,7 +86,7 @@ struct SessionData {
         let activity = pickOne(
             from: activities,
             prompt: "Select activity",
-            label: { a in "\(a.name ?? a.id)  [\(a.status)]" }
+            label: { a in "\(a.name ?? a.id)  [\(a.status)]" + (a.activityType.map { "  \($0)" } ?? "") }
         )
 
         // Check status
@@ -149,35 +148,14 @@ struct SessionData {
         let selectedAnalysis = pickMulti(from: analysisDataTypes, prompt: "Select analysis data types", label: { $0.1 })
         let analysisDTypes = Set(selectedAnalysis.map { $0.0 })
 
-        // Metrics now come from the metrics table — the AnalysisDataType.metrics
-        // download is deprecated. Fetch them and save a single flat JSON.
-        if analysisDTypes.contains(.metrics) {
-            print("\nFetching metrics...")
-            do {
-                let metricsResult = try await service.activityMetrics(for: activity.id)
-                if let metrics = metricsResult, let data = metricsJSON(metrics) {
-                    let path = saveFile(named: "\(slug)_metrics.json", data: data)
-                    print("  Saved: \(path)")
-                } else {
-                    print("  No metrics available for this activity.")
-                }
-            } catch {
-                print("  Failed to fetch metrics: \(error)")
-            }
-        }
-
-        // Report and data files still download through the analysis data endpoint.
-        let fileTypes = analysisDTypes.subtracting([.metrics])
-        if !fileTypes.isEmpty {
-            print("\nDownloading analysis data...")
-            let analysisResults = await service.analysisData(ofType: fileTypes, for: activity)
-            if analysisResults.isEmpty {
-                print("  No analysis data available.")
-            } else {
-                for r in analysisResults {
-                    let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
-                    print("  Saved: \(path)")
-                }
+        print("\nDownloading analysis data...")
+        let analysisResults = await service.analysisData(ofType: analysisDTypes, for: activity)
+        if analysisResults.isEmpty {
+            print("  No analysis data available.")
+        } else {
+            for r in analysisResults {
+                let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
+                print("  Saved: \(path)")
             }
         }
 
@@ -209,25 +187,4 @@ struct SessionData {
 
         print("\nDone.")
     }
-}
-
-/// Flatten activity metrics into pretty-printed JSON.
-///
-/// Groups are discarded and every metric appears exactly once, keyed by name.
-/// Scalar metrics map to a number; bilateral metrics map to a
-/// { "left", "right" } object. The first occurrence of a name wins.
-private func metricsJSON(_ metrics: ActivityMetrics) -> Data? {
-    var flat: [String: Any] = [:]
-    for group in metrics.groups {
-        for metric in group.metrics where flat[metric.name] == nil {
-            switch metric.value {
-            case .scalar(let v):
-                flat[metric.name] = v ?? NSNull()
-            case .bilateral(let left, let right):
-                flat[metric.name] = ["left": left ?? NSNull(), "right": right ?? NSNull()]
-            }
-        }
-    }
-    let root: [String: Any] = ["activityId": metrics.activityId, "metrics": flat]
-    return try? JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
 }

--- a/examples/swift/Sources/SessionData/SessionData.swift
+++ b/examples/swift/Sources/SessionData/SessionData.swift
@@ -149,14 +149,35 @@ struct SessionData {
         let selectedAnalysis = pickMulti(from: analysisDataTypes, prompt: "Select analysis data types", label: { $0.1 })
         let analysisDTypes = Set(selectedAnalysis.map { $0.0 })
 
-        print("\nDownloading analysis data...")
-        let analysisResults = await service.analysisData(ofType: analysisDTypes, for: activity)
-        if analysisResults.isEmpty {
-            print("  No analysis data available.")
-        } else {
-            for r in analysisResults {
-                let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
-                print("  Saved: \(path)")
+        // Metrics now come from the metrics table — the AnalysisDataType.metrics
+        // download is deprecated. Fetch them and save a single flat JSON.
+        if analysisDTypes.contains(.metrics) {
+            print("\nFetching metrics...")
+            do {
+                let metricsResult = try await service.activityMetrics(for: activity.id)
+                if let metrics = metricsResult, let data = metricsJSON(metrics) {
+                    let path = saveFile(named: "\(slug)_metrics.json", data: data)
+                    print("  Saved: \(path)")
+                } else {
+                    print("  No metrics available for this activity.")
+                }
+            } catch {
+                print("  Failed to fetch metrics: \(error)")
+            }
+        }
+
+        // Report and data files still download through the analysis data endpoint.
+        let fileTypes = analysisDTypes.subtracting([.metrics])
+        if !fileTypes.isEmpty {
+            print("\nDownloading analysis data...")
+            let analysisResults = await service.analysisData(ofType: fileTypes, for: activity)
+            if analysisResults.isEmpty {
+                print("  No analysis data available.")
+            } else {
+                for r in analysisResults {
+                    let path = saveFile(named: "\(slug)_\(r.type.typeLabel).\(r.type.fileExtension)", data: r.data)
+                    print("  Saved: \(path)")
+                }
             }
         }
 
@@ -188,4 +209,25 @@ struct SessionData {
 
         print("\nDone.")
     }
+}
+
+/// Flatten activity metrics into pretty-printed JSON.
+///
+/// Groups are discarded and every metric appears exactly once, keyed by name.
+/// Scalar metrics map to a number; bilateral metrics map to a
+/// { "left", "right" } object. The first occurrence of a name wins.
+private func metricsJSON(_ metrics: ActivityMetrics) -> Data? {
+    var flat: [String: Any] = [:]
+    for group in metrics.groups {
+        for metric in group.metrics where flat[metric.name] == nil {
+            switch metric.value {
+            case .scalar(let v):
+                flat[metric.name] = v ?? NSNull()
+            case .bilateral(let left, let right):
+                flat[metric.name] = ["left": left ?? NSNull(), "right": right ?? NSNull()]
+            }
+        }
+    }
+    let root: [String: Any] = ["activityId": metrics.activityId, "metrics": flat]
+    return try? JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
 }

--- a/examples/swift/Sources/Shared/Shared.swift
+++ b/examples/swift/Sources/Shared/Shared.swift
@@ -83,15 +83,19 @@ public func pollAnalysis(service: ModelHealthService, task: Analysis) async thro
 
 // MARK: - Prompts
 
-public func pickOne<T>(from items: [T], prompt: String, label: (T) -> String) -> T {
+public func pickOne<T>(from items: [T], prompt: String, label: (T) -> String, defaultIndex: Int? = nil) -> T {
     for (i, item) in items.enumerated() {
-        print("  \(i + 1). \(label(item))")
+        let suffix = i == defaultIndex ? "  (default)" : ""
+        print("  \(i + 1). \(label(item))\(suffix)")
     }
+    let rangeHint = defaultIndex != nil ? "1–\(items.count), Enter for \(defaultIndex! + 1)" : "1–\(items.count)"
     while true {
-        print("\n\(prompt) (1–\(items.count)): ", terminator: "")
-        if let line = readLine(),
-           let n = Int(line.trimmingCharacters(in: .whitespaces)),
-           (1...items.count).contains(n) {
+        print("\n\(prompt) (\(rangeHint)): ", terminator: "")
+        let line = readLine()?.trimmingCharacters(in: .whitespaces) ?? ""
+        if line.isEmpty, let defaultIndex {
+            return items[defaultIndex]
+        }
+        if let n = Int(line), (1...items.count).contains(n) {
             return items[n - 1]
         }
         print("  Please enter a number between 1 and \(items.count).")

--- a/examples/swift/Sources/UpdateActivity/UpdateActivity.swift
+++ b/examples/swift/Sources/UpdateActivity/UpdateActivity.swift
@@ -82,12 +82,13 @@ struct UpdateActivity {
         let activity = pickOne(
             from: activities,
             prompt: "Select activity",
-            label: { "\($0.name ?? $0.id)  [\($0.status)]" }
+            label: { "\($0.name ?? $0.id)  [\($0.status)]" + ($0.activityType.map { "  \($0)" } ?? "") }
         )
         print("  Selected: \(activity.name ?? activity.id)")
 
         // Update
         print("\nUpdate activity (press Enter to keep current value):")
+        print("  Current activity type: \(activity.activityType.map { "\($0)" } ?? "(none)")")
         let currentTags = activity.tags.isEmpty ? "(none)" : activity.tags.joined(separator: ", ")
         print("  Current tags: \(currentTags)")
 

--- a/examples/ts/_shared.ts
+++ b/examples/ts/_shared.ts
@@ -22,7 +22,6 @@ export const MOTION_DATA_EXT: Record<string, string> = {
 };
 
 export const ANALYSIS_DATA_EXT: Record<string, string> = {
-  metrics: 'json',
   report:  'pdf',
   data:    'zip',
 };
@@ -120,12 +119,19 @@ export function closePrompts(): void {
 export async function pickOne<T>(
   items: T[],
   question: string,
-  label: (item: T) => string
+  label: (item: T) => string,
+  defaultItem?: T
 ): Promise<T> {
-  items.forEach((item, i) => console.log(`  ${i + 1}. ${label(item)}`));
+  const defaultIdx = defaultItem !== undefined ? items.indexOf(defaultItem) : -1;
+  items.forEach((item, i) => {
+    const suffix = i === defaultIdx ? '  (default)' : '';
+    console.log(`  ${i + 1}. ${label(item)}${suffix}`);
+  });
+  const rangeHint = defaultIdx >= 0 ? `1–${items.length}, Enter for ${defaultIdx + 1}` : `1–${items.length}`;
   while (true) {
-    const raw = await prompt(`\n${question} (1–${items.length}): `);
-    const n = parseInt(raw.trim(), 10);
+    const raw = (await prompt(`\n${question} (${rangeHint}): `)).trim();
+    if (raw === '' && defaultIdx >= 0) return items[defaultIdx];
+    const n = parseInt(raw, 10);
     if (!isNaN(n) && n >= 1 && n <= items.length) return items[n - 1];
     console.log(`  Please enter a number between 1 and ${items.length}.`);
   }

--- a/examples/ts/activity_analysis.ts
+++ b/examples/ts/activity_analysis.ts
@@ -7,7 +7,7 @@
  */
 
 import { ModelHealthService, ActivityType } from '@modelhealth/modelhealth';
-import type { AnalysisDataType, ActivityMetrics } from '@modelhealth/modelhealth';
+import type { AnalysisDataType } from '@modelhealth/modelhealth';
 import {
   loadApiKey, INTERNAL_ACTIVITY_NAMES, ANALYSIS_DATA_EXT,
   pickOne, pickMulti, saveFile, pollAnalysis, sleep, closePrompts,
@@ -32,7 +32,6 @@ const ANALYSIS_TYPES: [string, string][] = [
 ];
 
 const RESULT_TYPES: [AnalysisDataType, string][] = [
-  ['metrics', 'Metrics  (JSON)'],
   ['report',  'Report   (PDF) '],
   ['data',    'Data     (ZIP) '],
 ];
@@ -67,7 +66,11 @@ async function main() {
   if (!activities.length) { console.error('No activities found in this session.'); process.exit(1); }
 
   console.log(`\n${activities.length} activity/activities:\n`);
-  const activity = await pickOne(activities, 'Select activity', a => `${a.name ?? a.id}  [${a.status}]`);
+  const activity = await pickOne(
+    activities,
+    'Select activity',
+    a => `${a.name ?? a.id}  [${a.status}]` + (a.activityType ? `  ${a.activityType}` : '')
+  );
 
   // Wait for ready
   const activityLabel = activity.name ?? activity.id;
@@ -85,9 +88,12 @@ async function main() {
   }
   console.log('Activity is ready.');
 
-  // Analysis type
+  // Analysis type — default to the activity's recorded type if available.
+  const defaultAnalysis = ANALYSIS_TYPES.find(t => t[0] === activity.activityType);
   console.log('\nAnalysis type:\n');
-  const [analysisType, analysisLabel] = await pickOne(ANALYSIS_TYPES, 'Select analysis type', t => t[1]);
+  const [analysisType, analysisLabel] = await pickOne(
+    ANALYSIS_TYPES, 'Select analysis type', t => t[1], defaultAnalysis
+  );
 
   // Run
   console.log(`\nStarting '${analysisLabel}' analysis...`);
@@ -111,55 +117,15 @@ async function main() {
 
   const slug = (freshActivity.name ?? freshActivity.id).replace(/ /g, '_');
 
-  // Metrics now come from the metrics table — the AnalysisDataType.metrics
-  // download is deprecated. Fetch them and save a single flat JSON.
-  if (dataTypes.includes('metrics')) {
-    console.log('\nFetching metrics...');
-    let metrics: ActivityMetrics;
-    try {
-      metrics = await service.activityMetrics(freshActivity.id);
-    } catch (err: any) {
-      console.error(`Failed to fetch activity metrics: ${err.message ?? err}`);
-      process.exit(1);
-    }
-    const json = JSON.stringify(metricsToDict(metrics), null, 2);
-    const p = saveFile(`${slug}_metrics.json`, Buffer.from(json, 'utf-8'));
+  console.log('\nDownloading...');
+  const results = await service.analysisDataForActivity(freshActivity, dataTypes);
+  for (const r of results) {
+    const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
+    const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
     console.log(`  Saved ${p}`);
   }
 
-  // Report and data files still download through the analysis data endpoint.
-  const fileTypes = dataTypes.filter(t => t !== 'metrics');
-  if (fileTypes.length) {
-    console.log('\nDownloading...');
-    const results = await service.analysisDataForActivity(freshActivity, fileTypes);
-    for (const r of results) {
-      const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
-      const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
-      console.log(`  Saved ${p}`);
-    }
-  }
-
   console.log('\nDone.');
-}
-
-/**
- * Flatten activity metrics into a plain object for JSON serialisation.
- * Groups are discarded and every metric appears exactly once, keyed by name.
- * Scalar metrics map to a number; bilateral metrics map to a
- * { left, right } object. The first occurrence of a name wins.
- */
-function metricsToDict(metrics: ActivityMetrics) {
-  const flat: Record<string, number | null | { left: number | null; right: number | null }> = {};
-  for (const group of metrics.groups) {
-    for (const metric of group.metrics) {
-      if (metric.name in flat) continue;
-      const value = metric.value;
-      flat[metric.name] = value.type === 'bilateral'
-        ? { left: value.left ?? null, right: value.right ?? null }
-        : value.value ?? null;
-    }
-  }
-  return { activityId: metrics.activityId, metrics: flat };
 }
 
 async function pollActivity(

--- a/examples/ts/activity_analysis.ts
+++ b/examples/ts/activity_analysis.ts
@@ -7,7 +7,7 @@
  */
 
 import { ModelHealthService, ActivityType } from '@modelhealth/modelhealth';
-import type { AnalysisDataType } from '@modelhealth/modelhealth';
+import type { AnalysisDataType, ActivityMetrics } from '@modelhealth/modelhealth';
 import {
   loadApiKey, INTERNAL_ACTIVITY_NAMES, ANALYSIS_DATA_EXT,
   pickOne, pickMulti, saveFile, pollAnalysis, sleep, closePrompts,
@@ -109,16 +109,57 @@ async function main() {
   const selected = await pickMulti(RESULT_TYPES, 'Select result types', r => r[1]);
   const dataTypes = selected.map(r => r[0]);
 
-  console.log('\nDownloading...');
-  const results = await service.analysisDataForActivity(freshActivity, dataTypes);
   const slug = (freshActivity.name ?? freshActivity.id).replace(/ /g, '_');
-  for (const r of results) {
-    const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
-    const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
+
+  // Metrics now come from the metrics table — the AnalysisDataType.metrics
+  // download is deprecated. Fetch them and save a single flat JSON.
+  if (dataTypes.includes('metrics')) {
+    console.log('\nFetching metrics...');
+    let metrics: ActivityMetrics;
+    try {
+      metrics = await service.activityMetrics(freshActivity.id);
+    } catch (err: any) {
+      console.error(`Failed to fetch activity metrics: ${err.message ?? err}`);
+      process.exit(1);
+    }
+    const json = JSON.stringify(metricsToDict(metrics), null, 2);
+    const p = saveFile(`${slug}_metrics.json`, Buffer.from(json, 'utf-8'));
     console.log(`  Saved ${p}`);
   }
 
+  // Report and data files still download through the analysis data endpoint.
+  const fileTypes = dataTypes.filter(t => t !== 'metrics');
+  if (fileTypes.length) {
+    console.log('\nDownloading...');
+    const results = await service.analysisDataForActivity(freshActivity, fileTypes);
+    for (const r of results) {
+      const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
+      const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
+      console.log(`  Saved ${p}`);
+    }
+  }
+
   console.log('\nDone.');
+}
+
+/**
+ * Flatten activity metrics into a plain object for JSON serialisation.
+ * Groups are discarded and every metric appears exactly once, keyed by name.
+ * Scalar metrics map to a number; bilateral metrics map to a
+ * { left, right } object. The first occurrence of a name wins.
+ */
+function metricsToDict(metrics: ActivityMetrics) {
+  const flat: Record<string, number | null | { left: number | null; right: number | null }> = {};
+  for (const group of metrics.groups) {
+    for (const metric of group.metrics) {
+      if (metric.name in flat) continue;
+      const value = metric.value;
+      flat[metric.name] = value.type === 'bilateral'
+        ? { left: value.left ?? null, right: value.right ?? null }
+        : value.value ?? null;
+    }
+  }
+  return { activityId: metrics.activityId, metrics: flat };
 }
 
 async function pollActivity(

--- a/examples/ts/activity_metrics.ts
+++ b/examples/ts/activity_metrics.ts
@@ -10,9 +10,10 @@
 
 import { ModelHealthService } from '@modelhealth/modelhealth';
 import type { ActivityMetrics, MetricValue } from '@modelhealth/modelhealth';
+import { activityMetricsToJson } from '@modelhealth/modelhealth';
 import {
   loadApiKey, INTERNAL_ACTIVITY_NAMES,
-  pickOne, closePrompts,
+  pickOne, confirm, saveFile, closePrompts,
 } from './_shared.js';
 
 async function main() {
@@ -57,6 +58,12 @@ async function main() {
     console.log('\nActivity metrics:\n');
     for (const [name, value] of flat) {
       console.log(`  ${name}: ${formatValue(value)}`);
+    }
+
+    if (await confirm('\nSave metrics as JSON?', false)) {
+      const slug = activityLabel.replace(/ /g, '_');
+      const p = saveFile(`${slug}_metrics.json`, Buffer.from(activityMetricsToJson(metrics), 'utf-8'));
+      console.log(`  Saved ${p}`);
     }
   }
 

--- a/examples/ts/activity_metrics.ts
+++ b/examples/ts/activity_metrics.ts
@@ -2,15 +2,14 @@
  * Model Health TypeScript SDK — retrieve biomechanical metrics.
  * Mirrors examples/python/activity_metrics.py.
  *
- * Demonstrates activityMetrics (single-activity dashboard metrics) and
- * subjectMetrics (all metrics across activities for a subject, with optional
- * date filtering).
+ * Demonstrates activityMetrics (single-activity dashboard metrics).
  *
  * Usage:
  *   npx tsx activity_metrics.ts [<api_key>]
  */
 
 import { ModelHealthService } from '@modelhealth/modelhealth';
+import type { ActivityMetrics, MetricValue } from '@modelhealth/modelhealth';
 import {
   loadApiKey, INTERNAL_ACTIVITY_NAMES,
   pickOne, closePrompts,
@@ -51,49 +50,33 @@ async function main() {
   console.log(`\nFetching metrics for '${activityLabel}'...`);
   const metrics = await service.activityMetrics(activity.id);
 
-  if (!metrics.groups.length) {
+  const flat = flattenMetrics(metrics);
+  if (!flat.size) {
     console.log('  No metrics available for this activity.');
   } else {
-    console.log(`\nActivity metrics (activity type ID: ${metrics.activityTypeId}):\n`);
-    for (const group of metrics.groups) {
-      console.log(`  ${group.name}`);
-      for (const metric of group.metrics) {
-        console.log(`    ${metric.name}: ${formatValue(metric.value)}`);
-      }
-    }
-  }
-
-  // Subject metrics (optional)
-  console.log('\n' + '-'.repeat(40));
-  const subjects = await service.subjectList();
-  if (!subjects.length) {
-    console.log('\nNo subjects found — skipping subject metrics.');
-    console.log('\nDone.');
-    return;
-  }
-
-  console.log(`\n${subjects.length} subject(s):\n`);
-  const subject = await pickOne(subjects, 'Select subject (or Ctrl-C to skip)', s => `[ID: ${s.id}]  ${s.name}`);
-
-  console.log(`\nFetching metrics for subject '${subject.name}' (ID: ${subject.id})...`);
-  const subjectMetrics = await service.subjectMetrics(subject.id);
-
-  if (!subjectMetrics.length) {
-    console.log('  No metrics found for this subject.');
-  } else {
-    console.log(`\n  ${subjectMetrics.length} activity result(s):\n`);
-    for (const am of subjectMetrics) {
-      const total = am.groups.reduce((n: number, g: { metrics: unknown[] }) => n + g.metrics.length, 0);
-      console.log(`  Activity ${am.activityId}  (type ID: ${am.activityTypeId})  — ${total} metric(s)`);
+    console.log('\nActivity metrics:\n');
+    for (const [name, value] of flat) {
+      console.log(`  ${name}: ${formatValue(value)}`);
     }
   }
 
   console.log('\nDone.');
 }
 
-type MetricValue =
-  | { type: 'scalar'; value: number | null }
-  | { type: 'bilateral'; left: number | null; right: number | null };
+/**
+ * Collapse the grouped metrics into a flat name -> value map.
+ * Groups are discarded and each metric appears exactly once; the first
+ * occurrence of a name wins.
+ */
+function flattenMetrics(metrics: ActivityMetrics): Map<string, MetricValue> {
+  const flat = new Map<string, MetricValue>();
+  for (const group of metrics.groups) {
+    for (const metric of group.metrics) {
+      if (!flat.has(metric.name)) flat.set(metric.name, metric.value);
+    }
+  }
+  return flat;
+}
 
 function formatValue(v: MetricValue): string {
   if (v.type === 'scalar') return v.value != null ? String(v.value) : '—';

--- a/examples/ts/activity_recording.ts
+++ b/examples/ts/activity_recording.ts
@@ -290,7 +290,16 @@ async function recordOne(
     console.log(`Activity did not reach ready state (status: ${finalStatus.type}).`);
   }
 
-  // Update activity metadata (optional)
+  // Update activity metadata (optional).
+  // Re-fetch first: analysis auto-generates tags server-side, and updateActivity
+  // merges add/remove tags on top of the local activity's tags. Without a fresh
+  // fetch, the merge starts from a stale tag set and wipes the auto-generated tags.
+  try {
+    currentActivity = await service.fetchActivity(currentActivity.id);
+  } catch (err: any) {
+    console.error(`Failed to refresh activity: ${err.message ?? err}`);
+  }
+
   console.log('\nUpdate activity (optional):');
   const currentTags = currentActivity.tags?.length ? currentActivity.tags.join(', ') : '(none)';
   console.log(`  Current tags: ${currentTags}`);

--- a/examples/ts/session_data.ts
+++ b/examples/ts/session_data.ts
@@ -7,7 +7,7 @@
  */
 
 import { ModelHealthService, ActivityType } from '@modelhealth/modelhealth';
-import type { VideoVersion, MotionDataType, AnalysisDataType, ActivityMetrics } from '@modelhealth/modelhealth';
+import type { VideoVersion, MotionDataType, AnalysisDataType } from '@modelhealth/modelhealth';
 import {
   loadApiKey, INTERNAL_ACTIVITY_NAMES, MOTION_DATA_EXT, ANALYSIS_DATA_EXT,
   pickOne, pickMulti, saveFile, closePrompts,
@@ -26,7 +26,6 @@ const MOTION_DATA_TYPES: [MotionDataType, string][] = [
 ];
 
 const ANALYSIS_DATA_TYPES: [AnalysisDataType, string][] = [
-  ['metrics', 'Metrics  (JSON)'],
   ['report',  'Report   (PDF) '],
   ['data',    'Data     (ZIP) '],
 ];
@@ -59,7 +58,11 @@ async function main() {
   if (!activities.length) { console.error('No activities found in this session.'); process.exit(1); }
 
   console.log(`\n${activities.length} activity/activities:\n`);
-  const activity = await pickOne(activities, 'Select activity', a => `${a.name ?? a.id}  [${a.status}]`);
+  const activity = await pickOne(
+    activities,
+    'Select activity',
+    a => `${a.name ?? a.id}  [${a.status}]` + (a.activityType ? `  ${a.activityType}` : '')
+  );
 
   // Check status
   const activityLabel = activity.name ?? activity.id;
@@ -114,33 +117,15 @@ async function main() {
   const selectedAnalysis = await pickMulti(ANALYSIS_DATA_TYPES, 'Select analysis data types', t => t[1]);
   const analysisTypes = selectedAnalysis.map(t => t[0]);
 
-  // Metrics now come from the metrics table — the AnalysisDataType.metrics
-  // download is deprecated. Fetch them and save a single flat JSON.
-  if (analysisTypes.includes('metrics')) {
-    console.log('\nFetching metrics...');
-    try {
-      const metrics = await service.activityMetrics(activity.id);
-      const json = JSON.stringify(metricsToDict(metrics), null, 2);
-      const p = saveFile(`${slug}_metrics.json`, Buffer.from(json, 'utf-8'));
+  console.log('\nDownloading analysis data...');
+  const analysisResults = await service.analysisDataForActivity(activity, analysisTypes);
+  if (!analysisResults.length) {
+    console.log('  No analysis data available.');
+  } else {
+    for (const r of analysisResults) {
+      const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
+      const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
       console.log(`  Saved: ${p}`);
-    } catch (err: any) {
-      console.log(`  Failed to fetch metrics: ${err.message ?? err}`);
-    }
-  }
-
-  // Report and data files still download through the analysis data endpoint.
-  const fileTypes = analysisTypes.filter(t => t !== 'metrics');
-  if (fileTypes.length) {
-    console.log('\nDownloading analysis data...');
-    const analysisResults = await service.analysisDataForActivity(activity, fileTypes);
-    if (!analysisResults.length) {
-      console.log('  No analysis data available.');
-    } else {
-      for (const r of analysisResults) {
-        const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
-        const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
-        console.log(`  Saved: ${p}`);
-      }
     }
   }
 
@@ -163,26 +148,6 @@ async function main() {
   }
 
   console.log('\nDone.');
-}
-
-/**
- * Flatten activity metrics into a plain object for JSON serialisation.
- * Groups are discarded and every metric appears exactly once, keyed by name.
- * Scalar metrics map to a number; bilateral metrics map to a
- * { left, right } object. The first occurrence of a name wins.
- */
-function metricsToDict(metrics: ActivityMetrics) {
-  const flat: Record<string, number | null | { left: number | null; right: number | null }> = {};
-  for (const group of metrics.groups) {
-    for (const metric of group.metrics) {
-      if (metric.name in flat) continue;
-      const value = metric.value;
-      flat[metric.name] = value.type === 'bilateral'
-        ? { left: value.left ?? null, right: value.right ?? null }
-        : value.value ?? null;
-    }
-  }
-  return { activityId: metrics.activityId, metrics: flat };
 }
 
 main().catch(err => { console.error(`Error: ${err.message ?? err}`); process.exit(1); })

--- a/examples/ts/session_data.ts
+++ b/examples/ts/session_data.ts
@@ -7,7 +7,7 @@
  */
 
 import { ModelHealthService, ActivityType } from '@modelhealth/modelhealth';
-import type { VideoVersion, MotionDataType, AnalysisDataType } from '@modelhealth/modelhealth';
+import type { VideoVersion, MotionDataType, AnalysisDataType, ActivityMetrics } from '@modelhealth/modelhealth';
 import {
   loadApiKey, INTERNAL_ACTIVITY_NAMES, MOTION_DATA_EXT, ANALYSIS_DATA_EXT,
   pickOne, pickMulti, saveFile, closePrompts,
@@ -114,15 +114,33 @@ async function main() {
   const selectedAnalysis = await pickMulti(ANALYSIS_DATA_TYPES, 'Select analysis data types', t => t[1]);
   const analysisTypes = selectedAnalysis.map(t => t[0]);
 
-  console.log('\nDownloading analysis data...');
-  const analysisResults = await service.analysisDataForActivity(activity, analysisTypes);
-  if (!analysisResults.length) {
-    console.log('  No analysis data available.');
-  } else {
-    for (const r of analysisResults) {
-      const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
-      const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
+  // Metrics now come from the metrics table — the AnalysisDataType.metrics
+  // download is deprecated. Fetch them and save a single flat JSON.
+  if (analysisTypes.includes('metrics')) {
+    console.log('\nFetching metrics...');
+    try {
+      const metrics = await service.activityMetrics(activity.id);
+      const json = JSON.stringify(metricsToDict(metrics), null, 2);
+      const p = saveFile(`${slug}_metrics.json`, Buffer.from(json, 'utf-8'));
       console.log(`  Saved: ${p}`);
+    } catch (err: any) {
+      console.log(`  Failed to fetch metrics: ${err.message ?? err}`);
+    }
+  }
+
+  // Report and data files still download through the analysis data endpoint.
+  const fileTypes = analysisTypes.filter(t => t !== 'metrics');
+  if (fileTypes.length) {
+    console.log('\nDownloading analysis data...');
+    const analysisResults = await service.analysisDataForActivity(activity, fileTypes);
+    if (!analysisResults.length) {
+      console.log('  No analysis data available.');
+    } else {
+      for (const r of analysisResults) {
+        const ext = ANALYSIS_DATA_EXT[r.type] ?? 'bin';
+        const p = saveFile(`${slug}_${r.type}.${ext}`, r.data);
+        console.log(`  Saved: ${p}`);
+      }
     }
   }
 
@@ -145,6 +163,26 @@ async function main() {
   }
 
   console.log('\nDone.');
+}
+
+/**
+ * Flatten activity metrics into a plain object for JSON serialisation.
+ * Groups are discarded and every metric appears exactly once, keyed by name.
+ * Scalar metrics map to a number; bilateral metrics map to a
+ * { left, right } object. The first occurrence of a name wins.
+ */
+function metricsToDict(metrics: ActivityMetrics) {
+  const flat: Record<string, number | null | { left: number | null; right: number | null }> = {};
+  for (const group of metrics.groups) {
+    for (const metric of group.metrics) {
+      if (metric.name in flat) continue;
+      const value = metric.value;
+      flat[metric.name] = value.type === 'bilateral'
+        ? { left: value.left ?? null, right: value.right ?? null }
+        : value.value ?? null;
+    }
+  }
+  return { activityId: metrics.activityId, metrics: flat };
 }
 
 main().catch(err => { console.error(`Error: ${err.message ?? err}`); process.exit(1); })

--- a/examples/ts/update_activity.ts
+++ b/examples/ts/update_activity.ts
@@ -66,12 +66,13 @@ async function main() {
   const activity = await pickOne(
     activities,
     'Select activity',
-    a => `${a.name ?? a.id}  [${a.status}]`
+    a => `${a.name ?? a.id}  [${a.status}]` + (a.activityType ? `  ${a.activityType}` : '')
   );
   console.log(`  Selected: ${activity.name ?? activity.id}`);
 
   // Update
   console.log('\nUpdate activity (press Enter to keep current value):');
+  console.log(`  Current activity type: ${activity.activityType ?? '(none)'}`);
   const currentTags = activity.tags?.length ? activity.tags.join(', ') : '(none)';
   console.log(`  Current tags: ${currentTags}`);
 


### PR DESCRIPTION
# Examples: mirror the Python v2/metrics fixes in Swift & TypeScript

Ports the example changes from #32 (Python) to the Swift and TypeScript example
sets. Only three of the six Python changes have Swift/TS counterparts — see
"Not ported" below.

## Metrics: migrate to the metrics table

The `AnalysisDataType.metrics` download is deprecated; metrics now come from the
metrics table via `activityMetrics`.

- **`activity_analysis.ts`, `session_data.ts`, `ActivityAnalysis.swift`,
  `SessionData.swift`** — when `metrics` is selected, fetch via `activityMetrics`
  and save a single flat JSON (`<slug>_metrics.json`) instead of the deprecated
  analysis-data download. Report and data files still download through
  `analysisData` / `analysisDataForActivity`. Adds a per-file `metricsToDict`
  (TS) / `metricsJSON` (Swift) helper (scalar → number, bilateral →
  `{ left, right }`, first-occurrence-wins), mirroring Python's `_metrics_to_dict`.
- **`activity_metrics.ts`, `ActivityMetrics.swift`** — scoped down to
  single-activity metrics only (dropped the `subjectMetrics` demo). Flattens the
  grouped metrics to a `name → value` mapping and drops the `activityTypeId`
  display. Docstrings updated.

## Recording

- **`activity_recording.ts`, `ActivityRecording.swift`** — re-fetch the activity
  (`fetchActivity` / `fetch(activity:)`) before the update step. Analysis
  auto-generates tags server-side, and the update merges add/remove tags on top
  of the local activity's tags — without a fresh fetch the merge starts from a
  stale set and wipes the auto-generated tags.

## Not ported

- **`opencap_import.py`** — no Swift/TS example exists, so its fixes (trial-meta
  strip, `augmentermodel → coreengine` precedence, drop `posemodel`, remove
  framerate override) have no counterpart here.
- **`README.md`** — the Swift and TS example directories have no README, so the
  new `activity_metrics` / `update_activity` entries have no counterpart.

## Testing

- TypeScript: type-checked with `tsc --noEmit` against SDK **0.5.13**. The
  metrics/re-fetch logic compiles clean.
- Swift: not built (SDK package not available locally). Every API used was
  verified against the SDK source in `model-health-internal`
  (`activityMetrics(for:) -> ActivityMetrics?`, `MetricValue.scalar/.bilateral`,
  `fetch(activity:)`).

## Notes / potential problems

1. **JSON key casing diverges from Python.** The saved metrics JSON uses
   `"activityId"` (camelCase, matching the Swift/TS SDK field names) where Python
   writes `"activity_id"`. So the output files are not byte-identical across
   languages. Easy to switch to `activity_id` if cross-language output
   consistency is preferred.

2. **Pre-existing example ↔ 0.5.13 SDK type mismatches** (surfaced by `tsc`, NOT
   introduced by this PR — they also appear in untouched files):
   - `Activity` has no `tags` property in the 0.5.13 types, yet
     `activity_recording.ts` and `update_activity.ts` read `activity.tags`.
   - `AnalysisData`/`MotionData` `.type` can be a `tagged` object, which can't
     index the `Record<string, string>` extension maps
     (`ANALYSIS_DATA_EXT[r.type]`, `MOTION_DATA_EXT[r.type]`) — present in the
     untouched motion-data block too.
   These suggest the examples and the shipped SDK types have drifted; worth a
   follow-up but out of scope here.

3. **Swift unverified by build.** Signatures were checked against source but no
   compiler ran — worth a `swift build` on a machine with the package before merge.
